### PR TITLE
Have models shut down when their host component unmounts

### DIFF
--- a/src/games/Lexible/assets/words/badwords.ts
+++ b/src/games/Lexible/assets/words/badwords.ts
@@ -1,4 +1,4 @@
-export const badWords = `ANAL
+export const badWordList = `ANAL
 ANALANNIE
 ANALPROBE
 ANALSEX

--- a/src/games/Lexible/models/ClientModel.ts
+++ b/src/games/Lexible/models/ClientModel.ts
@@ -97,12 +97,12 @@ export class LexibleClientModel extends ClusterfunClientModel  {
     constructor(sessionHelper: ISessionHelper, playerName: string, logger: ITelemetryLogger, storage: IStorage) {
         super("LexibleClient", sessionHelper, playerName, logger, storage);
 
-        sessionHelper.addListener(LexiblePlayRequestMessage, playerName, this.handlePlayRequestMessage);
-        sessionHelper.addListener(LexibleRecentlyTouchedLettersMessage, playerName, this.handleRecentlyTouchedMessage);
-        sessionHelper.addListener(LexibleEndOfRoundMessage, playerName, this.handleEndOfRoundMessage);
-        sessionHelper.addListener(LexibleScoredWordMessage, playerName, this.handleScoredWordMessage);
-        sessionHelper.addListener(LexibleFailedWordMessage, playerName, this.handleFailedWordMessage);
-        sessionHelper.addListener(LexibleWordHintMessage, playerName, this.handleWordHintMessage);
+        sessionHelper.addListener(LexiblePlayRequestMessage, this, this.handlePlayRequestMessage);
+        sessionHelper.addListener(LexibleRecentlyTouchedLettersMessage, this, this.handleRecentlyTouchedMessage);
+        sessionHelper.addListener(LexibleEndOfRoundMessage, this, this.handleEndOfRoundMessage);
+        sessionHelper.addListener(LexibleScoredWordMessage, this, this.handleScoredWordMessage);
+        sessionHelper.addListener(LexibleFailedWordMessage, this, this.handleFailedWordMessage);
+        sessionHelper.addListener(LexibleWordHintMessage, this, this.handleWordHintMessage);
 
         makeObservable(this);
     }

--- a/src/games/Lexible/models/PresenterModel.ts
+++ b/src/games/Lexible/models/PresenterModel.ts
@@ -281,6 +281,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
         for (const word of words) {
             if (window.performance.now() - lastAwaitTime > 10) {
                 await this.waitForRealTime(0);
+                if (this.isShutdown) return;
                 lastAwaitTime = window.performance.now();
             }
             this.wordTree.add(word.trim());
@@ -288,10 +289,12 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
         }
         Logger.info(`Loaded ${this.wordSet.size} words`)
 
-        const { badWords } = await badWordsPromise;
+        const { badWordList } = await badWordsPromise;
+        const badWords = badWordList.split('\n');
         for (const badWord of badWords) {
             if (window.performance.now() - lastAwaitTime > 5) {
                 await this.waitForRealTime(0);
+                if (this.isShutdown) return;
                 lastAwaitTime = window.performance.now();
             }
             this.badWords.add(badWord.trim());

--- a/src/games/Lexible/models/PresenterModel.ts
+++ b/src/games/Lexible/models/PresenterModel.ts
@@ -225,7 +225,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
         this.allowedJoinStates.push(LexibleGameState.Playing, GeneralGameState.Paused)
         this.subscribe(PresenterGameEvent.PlayerJoined, this.name, this.handlePlayerJoin)
 
-        sessionHelper.addListener(LexiblePlayerActionMessage, `${this.name}_action`, this.handlePlayerAction);
+        sessionHelper.addListener(LexiblePlayerActionMessage, this, this.handlePlayerAction);
 
         sessionHelper.onError(err => {
             Logger.error(`Session error: ${err}`)

--- a/src/games/TestGame/models/ClientModel.ts
+++ b/src/games/TestGame/models/ClientModel.ts
@@ -69,8 +69,8 @@ export class TestatoClientModel extends ClusterfunClientModel  {
         this.ballData.xm = (this.randomDouble(.01) + 0.005) * (this.randomInt(2) ? 1 : -1) ;
         this.ballData.ym = (this.randomDouble(.01) + 0.005) * (this.randomInt(2) ? 1 : -1) ;
         this.ballData.color = this.randomItem(colors);
-        sessionHelper.addListener(TestatoPlayRequestMessage, playerName, this.handlePlayRequestMessage);
-        sessionHelper.addListener(TestatoEndOfRoundMessage, playerName, this.handleEndOfRoundMessage);
+        sessionHelper.addListener(TestatoPlayRequestMessage, this, this.handlePlayRequestMessage);
+        sessionHelper.addListener(TestatoEndOfRoundMessage, this, this.handleEndOfRoundMessage);
     }
 
     // -------------------------------------------------------------------

--- a/src/games/TestGame/models/PresenterModel.ts
+++ b/src/games/TestGame/models/PresenterModel.ts
@@ -104,7 +104,7 @@ export class TestatoPresenterModel extends ClusterfunPresenterModel<TestatoPlaye
         super("Testato", sessionHelper, logger, storage);
         Logger.info(`Constructing TestatoPresenterModel ${this.gameState}`)
 
-        sessionHelper.addListener(TestatoPlayerActionMessage, "answer", this.handlePlayerAction);
+        sessionHelper.addListener(TestatoPlayerActionMessage, this, this.handlePlayerAction);
 
         this.allowedJoinStates = [PresenterGameState.Gathering, TestatoGameState.Playing]
 

--- a/src/games/stressgame/models/ClientModel.ts
+++ b/src/games/stressgame/models/ClientModel.ts
@@ -93,7 +93,7 @@ export class StressatoClientModel extends ClusterfunClientModel  {
             }
         })
 
-        sessionHelper.addListener(StressatoServerActionMessage, playerName, this.handleActionMessage);
+        sessionHelper.addListener(StressatoServerActionMessage, this, this.handleActionMessage);
         makeObservable(this);
     }
 

--- a/src/games/stressgame/models/PresenterModel.ts
+++ b/src/games/stressgame/models/PresenterModel.ts
@@ -135,7 +135,7 @@ export class StressatoPresenterModel extends ClusterfunPresenterModel<StressatoP
         storage: IStorage)
     {
         super("Stressato", sessionHelper, logger, storage);
-        sessionHelper.addListener(StressatoPlayerActionMessage, "answer", this.handlePlayerAction);
+        sessionHelper.addListener(StressatoPlayerActionMessage, this, this.handlePlayerAction);
         this.allowedJoinStates = [PresenterGameState.Gathering, StressatoGameState.Playing]
         this.minPlayers = 1;
 

--- a/src/libs/GameModel/BaseGameModel.ts
+++ b/src/libs/GameModel/BaseGameModel.ts
@@ -166,7 +166,7 @@ export abstract class BaseGameModel  {
         this.storage = storage;
 
         this._scheduledEvents = new Map<number, Array<() => void>>();
-        this.session.addClosedListener(code => this.onSessionClosed(code));
+        this.session.addClosedListener(this, code => this.onSessionClosed(code));
    
         // Set up a regular ticker to drive scheduled events and animations
         let timeOfLastTick = Date.now();
@@ -258,17 +258,6 @@ export abstract class BaseGameModel  {
         }
 
         this._events!.get(event)!.subscribe(subscriptionId, callback);
-    }
-
-    // -------------------------------------------------------------------
-    // addMessageListener - register a listening for a specific clusterfun
-    // message type.
-    // -------------------------------------------------------------------
-    addMessageListener<P, M extends ClusterFunMessageBase>(
-        messageClass: ClusterFunMessageConstructor<P, M>, 
-        name: string, 
-        listener: (message: M) => unknown) {
-        this.session.addListener(messageClass, name, listener);
     }
 
     // -------------------------------------------------------------------

--- a/src/libs/GameModel/BaseGameModel.ts
+++ b/src/libs/GameModel/BaseGameModel.ts
@@ -1,10 +1,16 @@
 import { ClusterFunGameProps, ITypeHelper, ISessionHelper, ITelemetryLogger, 
-    IStorage, EventThing, ClusterFunMessageBase, ClusterFunMessageConstructor, 
+    IStorage, EventThing, ClusterFunMessageBase, 
     BaseAnimationController, ClusterFunReceiptAckMessage, BruteForceSerializer
 } from "../../libs";
 
 import { action, makeObservable, observable } from "mobx";
 import Logger from "js-logger";
+
+// Finalizer to track whether models have been properly cleared
+// Remove when debugging makes us confident of this
+const debug_model_finalizer = new FinalizationRegistry((name) => {
+    Logger.info(`Model with ${name} successfully garbage collected`);
+})
 
 
 const GAMESTATE_LABEL = "game_state";
@@ -64,6 +70,7 @@ function createSerializer(typeHelper: ITypeHelper)
                     case "_ticker":
                     case "_isCheckpointing":
                     case "_lastCheckpointTime":
+                    case "_isShutdown":
                     case "logger":
                     case "onTick":
                     case "serializer":
@@ -136,6 +143,9 @@ export abstract class BaseGameModel  {
     public onTick = new EventThing<number>("BaseGameModel");
     private _scheduledEvents: Map<number, Array<() => void>>;
 
+    private _isShutdown = false;
+    public get isShutdown() { return this._isShutdown; }
+
     //private _deserializeHelper: (propertyName: string, data: any) => any
     private _events = new Map<string, EventThing<any>>();
     private _ticker: NodeJS.Timeout;
@@ -177,6 +187,8 @@ export abstract class BaseGameModel  {
         }, this.tickInterval_ms );
 
         this.telemetryLogger.logPageView(name);
+
+        debug_model_finalizer.register(this, this.name);
     }
 
     // -------------------------------------------------------------------
@@ -227,8 +239,20 @@ export abstract class BaseGameModel  {
     quitApp = () => {
         Logger.info("Quitting the app")
         this.gameState = GeneralGameState.Destroyed;
-        clearInterval(this._ticker);
         this.storage.remove(GAMESTATE_LABEL);
+        this.shutdown();
+    }
+
+    // -------------------------------------------------------------------
+    //  shutdown - Shut down the model without destroying saved state
+    // -------------------------------------------------------------------
+    shutdown = () => {
+        Logger.info("Shutting down model");
+        clearInterval(this._ticker);
+        this.session.removeAllListenersForOwner(this);
+        this._events.clear();
+        this._scheduledEvents.clear();
+        this._isShutdown = true;
     }
 
     // -------------------------------------------------------------------
@@ -264,9 +288,10 @@ export abstract class BaseGameModel  {
     // invokeEvent - force an event to trigger
     // -------------------------------------------------------------------
     invokeEvent(event: string, ...args: any[]) {
+        const eventFunction = this._events.get(event);
         return new Promise<void>(resolve => {
             setTimeout(() => {
-                this._events.get(event)?.invoke(...args);
+                eventFunction?.invoke(...args);
                 resolve();
             },1)            
         })
@@ -445,6 +470,4 @@ export abstract class BaseGameModel  {
     {
         return items[this.randomInt(items.length)]
     }
-    
-
 }

--- a/src/libs/GameModel/ClusterfunClientModel.ts
+++ b/src/libs/GameModel/ClusterfunClientModel.ts
@@ -49,12 +49,12 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
         makeObservable(this);
         this._playerName = playerName;
 
-        sessionHelper.addListener(ClusterFunJoinAckMessage, playerName, this.handleJoinAckMessage);
-        sessionHelper.addListener(ClusterFunGameOverMessage, playerName, this.handleGameOverMessage);
-        sessionHelper.addListener(ClusterFunTerminateGameMessage, playerName, this.handleTerminateGameMessage);
-        sessionHelper.addListener(ClusterFunGamePauseMessage, playerName, this.handlePauseMessage);
-        sessionHelper.addListener(ClusterFunServerStateMessage, playerName, this.handleServerStateMessage);
-        sessionHelper.addListener(ClusterFunGameResumeMessage, playerName, this.handleResumeMessage);
+        sessionHelper.addListener(ClusterFunJoinAckMessage, this, this.handleJoinAckMessage);
+        sessionHelper.addListener(ClusterFunGameOverMessage, this, this.handleGameOverMessage);
+        sessionHelper.addListener(ClusterFunTerminateGameMessage, this, this.handleTerminateGameMessage);
+        sessionHelper.addListener(ClusterFunGamePauseMessage, this, this.handlePauseMessage);
+        sessionHelper.addListener(ClusterFunServerStateMessage, this, this.handleServerStateMessage);
+        sessionHelper.addListener(ClusterFunGameResumeMessage, this, this.handleResumeMessage);
 
         sessionHelper.onError((err) => {
             Logger.error(`Session error: ${err}`)

--- a/src/libs/GameModel/ClusterfunPresenterModel.ts
+++ b/src/libs/GameModel/ClusterfunPresenterModel.ts
@@ -108,10 +108,10 @@ export abstract class ClusterfunPresenterModel<PlayerType extends ClusterFunPlay
         this.gameTime_ms = 0;
         this.onTick.subscribe("PresenterState", ()=> this.manageState())
 
-        sessionHelper.addListener(ClusterFunJoinMessage, "playerJoin", this.handleJoinMessage);
-        sessionHelper.addListener(ClusterFunQuitMessage, "playerQuit", this.handlePlayerQuitMessage);
-        sessionHelper.addListener(ClusterFunReceiptAckMessage, "playerAck", this.handleReceipts)
-        sessionHelper.addListener(ClusterFunKeepAliveMessage, "keepAliveSignal", this.handleKeepAlive)
+        sessionHelper.addListener(ClusterFunJoinMessage, this, this.handleJoinMessage);
+        sessionHelper.addListener(ClusterFunQuitMessage, this, this.handlePlayerQuitMessage);
+        sessionHelper.addListener(ClusterFunReceiptAckMessage, this, this.handleReceipts)
+        sessionHelper.addListener(ClusterFunKeepAliveMessage, this, this.handleKeepAlive)
 
         this.gameState = PresenterGameState.Gathering;
 

--- a/src/libs/components/ClusterfunGameComponent.tsx
+++ b/src/libs/components/ClusterfunGameComponent.tsx
@@ -30,6 +30,13 @@ class DummyComponent extends React.Component<{ appModel?: any, uiProperties: UIP
     render() { return <div>DUMDUMDUM</div>}
 }
 
+const componentFinalizer = new FinalizationRegistry((model: BaseGameModel) => {
+    if (!model.isShutdown) {
+        Logger.warn("Component was finalized before model was shut down");
+        model.shutdown();
+    }
+})
+
 
 // -------------------------------------------------------------------
 // Main Game Page
@@ -75,6 +82,11 @@ extends React.Component<ClusterFunGameProps>
         this.appModel.subscribe(GeneralGameState.Destroyed, "GameOverCleanup", () => onGameEnded());
         document.title = `${gameProperties.gameName} / ClusterFun.tv`
         this.appModel!.tryLoadOldGame(this.props);
+        componentFinalizer.register(this, this.appModel!);
+    }
+
+    componentWillUnmount(): void {
+        this.appModel?.shutdown();
     }
     
 

--- a/src/libs/messaging/SessionHelper.ts
+++ b/src/libs/messaging/SessionHelper.ts
@@ -188,7 +188,6 @@ export class SessionHelper implements ISessionHelper {
             listenersForType.delete(owner);
             if (listenersForType.size === 0) {
                 this._listeners.delete(messageClass as ClusterFunMessageConstructor<unknown, M>);
-                this._serializer.unregister(messageClass);
                 Logger.debug("UNREGISTERING: " + messageClass.messageTypeName)
             }
         }

--- a/src/libs/messaging/SessionHelper.ts
+++ b/src/libs/messaging/SessionHelper.ts
@@ -21,10 +21,14 @@ export interface ISessionHelper {
     resendMessage(receiver: string, oldMessage: IMessageReceipt): void;
     addListener<P, M extends ClusterFunMessageBase>(
         messageClass: ClusterFunMessageConstructor<P, M>, 
-        name: string, 
+        owner: object, 
         listener: (message: M) => unknown): void;
-    addOpenedListener(listener: () => void): void;
-    addClosedListener(listener: (code: number) => void): void;
+    addClosedListener(owner: object, listener: (code: number) => void): void;
+    removeListener<P, M extends ClusterFunMessageBase>(
+        messageClass: ClusterFunMessageConstructor<P, M>, 
+        owner: object): void;
+    removeClosedListener(owner: object): void;
+    removeAllListenersForOwner(owner: object): void;
     onError(doThis: (err:string) => void): void;
     serverCall: <T>(url: string, payload: any ) => Promise<T>;
     stats: {
@@ -45,7 +49,8 @@ export class SessionHelper implements ISessionHelper {
     private readonly _presenterId: string;
     private readonly _serializer: ClusterFunSerializer;
     private _messageThing: IMessageThing;
-    private _listeners = new Map<ClusterFunMessageConstructor<unknown, ClusterFunMessageBase>, Map<string, (message: object) => void>>()
+    private _listeners = new Map<ClusterFunMessageConstructor<unknown, ClusterFunMessageBase>, Map<object, (message: ClusterFunMessageBase) => void>>()
+    private _closedListeners = new Map<object, (code: number) => void>();
     sessionError?:string;
     serverCall: <T>(url: string, payload: any) => Promise<T>;
     stats = {
@@ -95,7 +100,9 @@ export class SessionHelper implements ISessionHelper {
         })
 
         this._messageThing.addEventListener("close", (ev: { code: number }) => {
-
+            for (const listener of this._closedListeners.values()) {
+                listener(ev.code);
+            }
         })
 
         makeAutoObservable(this.stats);
@@ -147,38 +154,60 @@ export class SessionHelper implements ISessionHelper {
     // -------------------------------------------------------------------
     // addListener
     // ------------------------------------------------------------------- 
-    addListener<P, M extends ClusterFunMessageBase>(messageClass: ClusterFunMessageConstructor<P, M>, name: string, listener: (message: M) => unknown) {
+    addListener<P, M extends ClusterFunMessageBase>(messageClass: ClusterFunMessageConstructor<P, M>, owner: object, listener: (message: M) => unknown) {
         if(!this._listeners.has(messageClass as ClusterFunMessageConstructor<unknown, M>))
         {
             // Create the set of listeners for the new class,
             // also ensuring the class is registered in the hydrator
-            this._listeners.set(messageClass as ClusterFunMessageConstructor<unknown, M>, new Map<string, (message: object) => unknown>());
+            this._listeners.set(messageClass as ClusterFunMessageConstructor<unknown, M>, new Map());
             this._serializer.register(messageClass);
-            Logger.debug("REGISTERING: " + messageClass)
+            Logger.debug("REGISTERING: " + messageClass.messageTypeName)
         }
-        const listenersForType = this._listeners.get(messageClass as ClusterFunMessageConstructor<unknown, M>) as Map<string, (message: M) => unknown>;
-        listenersForType.set(name, listener);
-    }
-
-    // -------------------------------------------------------------------
-    // addOpenedListener
-    // ------------------------------------------------------------------- 
-    addOpenedListener(listener: () => void) {
-        if (this._messageThing.isOpen) {
-            setTimeout(() => listener(), 0);
-        } else {
-            this._messageThing.addEventListener("open", (ev) => listener());
-        }
+        const listenersForType = this._listeners.get(messageClass as ClusterFunMessageConstructor<unknown, M>) as Map<object, (message: M) => unknown>;
+        listenersForType.set(owner, listener);
     }
 
     // -------------------------------------------------------------------
     // addClosedListener
     // ------------------------------------------------------------------- 
-    addClosedListener(listener: (code: number) => void) {
+    addClosedListener(owner: object, listener: (code: number) => void) {
         if (this._messageThing.isClosed) {
-            setTimeout(() => listener(this._messageThing.closeCode), 0);
+            listener(this._messageThing.closeCode);
         } else {
-            this._messageThing.addEventListener("close", (ev) => listener(ev.code));
+            this._closedListeners.set(owner, listener);
         }
+    }
+
+    // -------------------------------------------------------------------
+    // removeListener
+    // ------------------------------------------------------------------- 
+    removeListener<P, M extends ClusterFunMessageBase>(messageClass: ClusterFunMessageConstructor<P, M>, owner: object) {
+        if(this._listeners.has(messageClass as ClusterFunMessageConstructor<unknown, M>))
+        {
+            const listenersForType = this._listeners.get(messageClass as ClusterFunMessageConstructor<unknown, M>)!;
+            listenersForType.delete(owner);
+            if (listenersForType.size === 0) {
+                this._listeners.delete(messageClass as ClusterFunMessageConstructor<unknown, M>);
+                this._serializer.unregister(messageClass);
+                Logger.debug("UNREGISTERING: " + messageClass.messageTypeName)
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // removeClosedListener
+    // ------------------------------------------------------------------- 
+    removeClosedListener(owner: object) {
+        this._closedListeners.delete(owner);
+    }
+
+    // -------------------------------------------------------------------
+    // removeAllListenersForOwner
+    // ------------------------------------------------------------------- 
+    removeAllListenersForOwner(owner: object) {
+        for (const messageType of this._listeners.keys()) {
+            this.removeListener(messageType, owner);
+        }
+        this.removeClosedListener(owner);
     }
 }


### PR DESCRIPTION
- When a game component unmounts, have its app model remove all external event handlers and shut off its timer, without disturbing saved game state.
- In support of this change, have message events be keyed by owning object instead of with a string name.
- Also fix bad word loading