### PR TITLE
Specify explicit type names when serializing

### DIFF
--- a/src/games/Lexible/models/ClientModel.ts
+++ b/src/games/Lexible/models/ClientModel.ts
@@ -18,6 +18,15 @@ export const getLexibleClientTypeHelper = (
  {
      return {
         rootTypeName: "LexibleClientModel",
+        getTypeName(o) {
+            switch (o.constructor) {
+                case LetterGridModel: return "LetterGridModel";
+                case LetterBlockModel: return "LetterBlockModel";
+                case Vector2: return "Vector2";
+                case LexibleClientModel: return "LexibleClientModel";
+                default: return undefined;
+            }
+        },
         constructType(typeName: string):any {
             switch(typeName)
             {

--- a/src/games/Lexible/models/PresenterModel.ts
+++ b/src/games/Lexible/models/PresenterModel.ts
@@ -81,6 +81,16 @@ export const getLexiblePresenterTypeHelper = (
  {
      return {
         rootTypeName: "LexiblePresenterModel",
+        getTypeName(o) {
+            switch (o.constructor) {
+                case LetterGridModel: return "LetterGridModel";
+                case LetterBlockModel: return "LetterBlockModel";
+                case LexiblePresenterModel: return "LexiblePresenterModel";
+                case LexiblePlayer: return "LexiblePlayer";
+                case Vector2: return "Vector2";
+            }
+            return undefined;
+        },
         constructType(typeName: string):any {
             switch(typeName)
             {
@@ -644,6 +654,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
         } else {
             Logger.warn("WEIRD: Player with unknown teamname")
         }
+        this.saveCheckpoint();
     }
 
     // -------------------------------------------------------------------

--- a/src/games/TestGame/models/ClientModel.ts
+++ b/src/games/TestGame/models/ClientModel.ts
@@ -15,6 +15,12 @@ export const getTestatoClientTypeHelper = (
  {
      return {
         rootTypeName: "TestatoClientModel",
+        getTypeName(o: object) {
+            switch (o.constructor) {
+                case TestatoClientModel: return "TestatoClientModel";
+            }
+            return undefined;
+        },
         constructType(typeName: string):any {
             switch(typeName)
             {

--- a/src/games/TestGame/models/PresenterModel.ts
+++ b/src/games/TestGame/models/PresenterModel.ts
@@ -47,6 +47,13 @@ export const getTestatoPresenterTypeHelper = (
  {
      return {
         rootTypeName: "TestatoPresenterModel",
+        getTypeName(o) {
+            switch (o.constructor) {
+                case TestatoPresenterModel: return "TestatoPresenterModel";
+                case TestatoPlayer: return "TestatoPlayer";
+            }
+            return undefined;
+        },
         constructType(typeName: string):any {
             switch(typeName)
             {

--- a/src/games/stressgame/models/ClientModel.ts
+++ b/src/games/stressgame/models/ClientModel.ts
@@ -15,6 +15,12 @@ export const getStressatoClientTypeHelper = (
  {
      return {
         rootTypeName: "StressatoClientModel",
+        getTypeName(o) {
+            switch (o.constructor) {
+                case StressatoClientModel: return "StressatoClientModel";
+            }
+            return undefined;
+        },
         constructType(typeName: string):any {
             switch(typeName)
             {

--- a/src/games/stressgame/models/PresenterModel.ts
+++ b/src/games/stressgame/models/PresenterModel.ts
@@ -42,6 +42,13 @@ export const getStressatoPresenterTypeHelper = (
  {
      return {
         rootTypeName: "StressatoPresenterModel",
+        getTypeName(o: object) {
+            switch (o.constructor) {
+                case StressatoPresenterModel: return "StressatoPresenterModel";
+                case StressatoPlayer: return "StressatoPlayer";
+            }
+            return undefined;
+        },
         constructType(typeName: string):any {
             switch(typeName)
             {

--- a/src/libs/GameModel/BaseGameModel.ts
+++ b/src/libs/GameModel/BaseGameModel.ts
@@ -46,8 +46,18 @@ export function instantiateGame<T extends BaseGameModel>(typeHelper: ITypeHelper
 // -------------------------------------------------------------------
 function createSerializer(typeHelper: ITypeHelper)
 {
-    const deepTypeHelper = {
+    const deepTypeHelper: ITypeHelper = {
         rootTypeName: "na",
+        getTypeName(o: object): string {
+            if (o.constructor === Object) return "Object";
+            if (o instanceof Map) return "Map";
+            if (o instanceof Set) return "Set";
+            const typeName = typeHelper.getTypeName(o);
+            if (!typeName) {
+                throw Error(`Object with constructor ${o.constructor.name} not added to getTypeName`);
+            }
+            return typeName;
+        },
         constructType(typeName: string) {
             const output = typeHelper.constructType(typeName);
             if(!output) {

--- a/src/libs/GameModel/ClusterfunClientModel.ts
+++ b/src/libs/GameModel/ClusterfunClientModel.ts
@@ -16,10 +16,13 @@ export enum GeneralClientGameState {
 // -------------------------------------------------------------------
 // Create the typehelper needed for loading and saving the game
 // -------------------------------------------------------------------
-export const getClientTypeHelper = (derivedClassHelper: ITypeHelper) =>
+export const getClientTypeHelper = (derivedClassHelper: ITypeHelper): ITypeHelper =>
  {
      return {
         rootTypeName: derivedClassHelper.rootTypeName,
+        getTypeName(o: object) {
+            return derivedClassHelper.getTypeName(o);
+        },
         constructType(typeName: string):any 
             { return derivedClassHelper.constructType(typeName); },
         shouldStringify(typeName: string, propertyName: string, object: any):boolean 

--- a/src/libs/GameModel/ClusterfunPresenterModel.ts
+++ b/src/libs/GameModel/ClusterfunPresenterModel.ts
@@ -32,10 +32,16 @@ export class ClusterFunPlayer
 // -------------------------------------------------------------------
 // Create the typehelper needed for loading and saving the game
 // -------------------------------------------------------------------
-export const getPresenterTypeHelper = (derivedClassHelper: ITypeHelper) =>
+export const getPresenterTypeHelper = (derivedClassHelper: ITypeHelper): ITypeHelper =>
  {
      return {
         rootTypeName: derivedClassHelper.rootTypeName,
+        getTypeName(o: object) {
+            switch(o.constructor) {
+                case ClusterFunPlayer: return "ClusterFunPlayer";
+            }
+            return derivedClassHelper.getTypeName(o);
+        },
         constructType(typeName: string):any { 
             switch(typeName){
                 case "ClusterFunPlayer": return new ClusterFunPlayer();

--- a/src/libs/storage/BruteForceSerializer.ts
+++ b/src/libs/storage/BruteForceSerializer.ts
@@ -95,7 +95,7 @@ export class BruteForceSerializer
         // Each new object has an id and a type name
         const output:any = {
             __i: this._objectCount++,
-            __t: normalizeMe.constructor?.name ?? "__unk__"
+            __t: this.typeHelper.getTypeName(normalizeMe)
         };
 
         // Remember that we have seen this object
@@ -230,6 +230,9 @@ export class BruteForceSerializer
 export interface ITypeHelper{
     // Gives the name for the root model type that will be used to instantiate the game
     rootTypeName: string;
+
+    // Return the type name to use for the given object
+    getTypeName(o: object): string | undefined;
 
     // This return a clean construction for the specified type
     constructType(typeName: string): object;


### PR DESCRIPTION
- This allows constructors to survive name mangling in production
- NOTE: The Lexible presenter does something weird that causes the grid to clear, and pending messages don't serialize properly. A fix for the latter is inherent in the request/response system, and I believe we have a grid fix there too.