### PR TITLE
Address feedback from request/response changes

### DIFF
--- a/src/games/Lexible/models/ClientModel.ts
+++ b/src/games/Lexible/models/ClientModel.ts
@@ -121,7 +121,7 @@ export class LexibleClientModel extends ClusterfunClientModel  {
     }
 
     async requestGameStateFromPresenter(): Promise<void> {
-        const onboardState = await this.session.request(LexibleOnboardClientEndpoint, this.session.presenterId, {})
+        const onboardState = await this.session.requestPresenter(LexibleOnboardClientEndpoint, {})
         if (onboardState.gameState === "Gathering") {
             this.gameState = GeneralClientGameState.WaitingToStart;
         } else {
@@ -172,7 +172,7 @@ export class LexibleClientModel extends ClusterfunClientModel  {
             letters: this.letterChain.map(l => ({letter: l.letter, coordinates: l.coordinates}))
         }
 
-        const response = await this.session.request(LexibleSubmitWordEndpoint, this.session.presenterId, submissionData)
+        const response = await this.session.requestPresenter(LexibleSubmitWordEndpoint, submissionData)
         if (response.success) {
             this.invokeEvent(LexibleGameEvent.WordAccepted)
         } else {
@@ -302,10 +302,10 @@ export class LexibleClientModel extends ClusterfunClientModel  {
                     if(this.letterChain.length === 0) this.wordList = []
                 }
 
-                this.session.request(LexibleRequestTouchLetterEndpoint, this.session.presenterId, {
+                this.session.requestPresenter(LexibleRequestTouchLetterEndpoint, {
                     touchPoint: block.coordinates
                 }).forget();
-                this.session.request(LexibleRequestWordHintsEndpoint, this.session.presenterId, {
+                this.session.requestPresenter(LexibleRequestWordHintsEndpoint, {
                     currentWord: this.letterChain.map(block => ({
                         letter: block.letter,
                         coordinates: block.coordinates

--- a/src/games/Lexible/models/ClientModel.ts
+++ b/src/games/Lexible/models/ClientModel.ts
@@ -305,17 +305,19 @@ export class LexibleClientModel extends ClusterfunClientModel  {
                 this.session.requestPresenter(LexibleRequestTouchLetterEndpoint, {
                     touchPoint: block.coordinates
                 }).forget();
-                this.session.requestPresenter(LexibleRequestWordHintsEndpoint, {
-                    currentWord: this.letterChain.map(block => ({
-                        letter: block.letter,
-                        coordinates: block.coordinates
-                    }))
-                }).then(hintResponse => {
-                    this.wordList = hintResponse.wordList;
-                    this.saveCheckpoint();
-                });
-                
-                this.saveCheckpoint();
+                if (isFirst) {
+                    this.session.requestPresenter(LexibleRequestWordHintsEndpoint, {
+                        currentWord: this.letterChain.map(block => ({
+                            letter: block.letter,
+                            coordinates: block.coordinates
+                        }))
+                    }).then(hintResponse => {
+                        action(() => { 
+                            this.wordList = hintResponse.wordList;
+                        })();
+                        this.saveCheckpoint();
+                    });
+                }
             })()
         }
     }

--- a/src/games/Lexible/models/ClientModel.ts
+++ b/src/games/Lexible/models/ClientModel.ts
@@ -114,9 +114,9 @@ export class LexibleClientModel extends ClusterfunClientModel  {
     // -------------------------------------------------------------------
     reconstitute() {
         super.reconstitute();
-        this.listenToEndpoint(LexibleShowRecentlyTouchedLettersEndpoint, this.handleRecentlyTouchedMessage);
-        this.listenToEndpoint(LexibleEndRoundEndpoint, this.handleEndOfRoundMessage);
-        this.listenToEndpoint(LexibleBoardUpdateEndpoint, this.handleBoardUpdateMessage); 
+        this.listenToEndpointFromPresenter(LexibleShowRecentlyTouchedLettersEndpoint, this.handleRecentlyTouchedMessage);
+        this.listenToEndpointFromPresenter(LexibleEndRoundEndpoint, this.handleEndOfRoundMessage);
+        this.listenToEndpointFromPresenter(LexibleBoardUpdateEndpoint, this.handleBoardUpdateMessage); 
         this.theGrid.processBlocks(b => this.setBlockHandlers(b))
     }
 
@@ -223,7 +223,7 @@ export class LexibleClientModel extends ClusterfunClientModel  {
         }
     }
 
-    protected handleBoardUpdateMessage = (sender: string, message: LexibleBoardUpdateNotification) => {
+    protected handleBoardUpdateMessage = (message: LexibleBoardUpdateNotification) => {
         message.letters.forEach(l => {
             const block = this.theGrid.getBlock(l.coordinates)
             if(!block) Logger.warn(`WEIRD: No block at ${l.coordinates}`)
@@ -237,7 +237,7 @@ export class LexibleClientModel extends ClusterfunClientModel  {
     // -------------------------------------------------------------------
     // handleRecentlyTouchedMessage
     // -------------------------------------------------------------------
-    protected handleRecentlyTouchedMessage = (sender: string, message: LexibleRecentlyTouchedLettersMessage) => {
+    protected handleRecentlyTouchedMessage = (message: LexibleRecentlyTouchedLettersMessage) => {
         message.letterCoordinates.forEach(c => {
             const block = this.theGrid.getBlock(c)
             if(!block) {
@@ -250,7 +250,7 @@ export class LexibleClientModel extends ClusterfunClientModel  {
     // -------------------------------------------------------------------
     // handleEndOfRoundMessage
     // -------------------------------------------------------------------
-    protected handleEndOfRoundMessage = (sender: string, message: LexibleEndOfRoundMessage) => {
+    protected handleEndOfRoundMessage = (message: LexibleEndOfRoundMessage) => {
         this.winningTeam = message.winningTeam;
         this.gameState = LexibleClientState.EndOfRound;
 

--- a/src/games/Lexible/models/PresenterModel.ts
+++ b/src/games/Lexible/models/PresenterModel.ts
@@ -424,7 +424,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
                 const letterCoordinates = Array.from(this.recentlyTouchedLetters.values());
                 this.recentlyTouchedLetters.clear();
                 const message: LexibleRecentlyTouchedLettersMessage = { letterCoordinates }
-                this.requestEveryone(LexibleShowRecentlyTouchedLettersEndpoint, () => message, true);
+                this.requestEveryoneAndForget(LexibleShowRecentlyTouchedLettersEndpoint, () => message);
             }
         }
     }
@@ -472,7 +472,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
             this.requestEveryone(GameOverEndpoint, (p,ie) => ({}))
         }    
         else {
-            this.requestEveryone(InvalidateStateEndpoint, (p, ie) => ({}), true);
+            this.requestEveryoneAndForget(InvalidateStateEndpoint, (p, ie) => ({}));
         }
         this.saveCheckpoint();
     }
@@ -578,9 +578,9 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
         }
         this.gameState = LexibleGameState.EndOfRound
         this.invokeEvent(LexibleGameEvent.TeamWon, team)
-        this.requestEveryone(LexibleEndRoundEndpoint, (p, ie) => {
+        this.requestEveryoneAndForget(LexibleEndRoundEndpoint, (p, ie) => {
             return { roundNumber: this.currentRound, winningTeam: team }
-        }, true)
+        })
     }
     
     // -------------------------------------------------------------------
@@ -610,14 +610,14 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
 
         if(word.length > player.longestWord.length) player.longestWord = word;
 
-        this.requestEveryone(LexibleBoardUpdateEndpoint, (p, isExited) => {
+        this.requestEveryoneAndForget(LexibleBoardUpdateEndpoint, (p, isExited) => {
             return {
                 letters: placedLetters,
                 score: word.length,
                 scoringPlayerId: player.playerId,
                 scoringTeam: player.teamName
             }
-        }, true);
+        });
 
         this.invokeEvent(LexibleGameEvent.WordAccepted, word.toLowerCase(), player)
         if (player.teamName === "A" || player.teamName === "B") {

--- a/src/games/TestGame/models/ClientModel.ts
+++ b/src/games/TestGame/models/ClientModel.ts
@@ -86,7 +86,7 @@ export class TestatoClientModel extends ClusterfunClientModel  {
     }
 
     async requestGameStateFromPresenter(): Promise<void> {
-        const response = await this.session.request(TestatoOnboardClientEndpoint, this.session.presenterId, {});
+        const response = await this.session.requestPresenter(TestatoOnboardClientEndpoint, {});
         this.roundNumber = response.roundNumber;
         switch(response.state) {
             case TestatoGameState.Playing: this.gameState = TestatoGameState.Playing; break;
@@ -136,7 +136,7 @@ export class TestatoClientModel extends ClusterfunClientModel  {
         const hex = Array.from("0123456789ABCDEF");
         let colorStyle = "#";
         for(let i = 0; i < 6; i++) colorStyle += this.randomItem(hex);
-        this.session.request(TestatoColorChangeActionEndpoint, this.session.presenterId, { colorStyle }).forget();
+        this.session.requestPresenter(TestatoColorChangeActionEndpoint, { colorStyle }).forget();
     }
    
     // -------------------------------------------------------------------
@@ -144,7 +144,7 @@ export class TestatoClientModel extends ClusterfunClientModel  {
     // -------------------------------------------------------------------
     doMessage(){
         const messages = ["Hi!", "Bye?", "What's up?", "Oh No!", "Hoooooweeee!!", "More gum."]
-        this.session.request(TestatoMessageActionEndpoint, this.session.presenterId, { message: this.randomItem(messages)}).forget();
+        this.session.requestPresenter(TestatoMessageActionEndpoint, { message: this.randomItem(messages)}).forget();
     }
    
     // -------------------------------------------------------------------
@@ -154,6 +154,6 @@ export class TestatoClientModel extends ClusterfunClientModel  {
         x = Math.floor(x * 1000)/1000;
         y = Math.floor(y * 1000)/1000;
         
-        this.session.request(TestatoTapActionEndpoint, this.session.presenterId, { point: new Vector2(x, y) }).forget();
+        this.session.requestPresenter(TestatoTapActionEndpoint, { point: new Vector2(x, y) }).forget();
     }
 }

--- a/src/games/TestGame/models/PresenterModel.ts
+++ b/src/games/TestGame/models/PresenterModel.ts
@@ -174,7 +174,7 @@ export class TestatoPresenterModel extends ClusterfunPresenterModel<TestatoPlaye
     // -------------------------------------------------------------------
     finishPlayingRound() {
         this.gameState = TestatoGameState.EndOfRound;
-        this.requestEveryone(InvalidateStateEndpoint, (p,ie) => ({}), true)
+        this.requestEveryoneAndForget(InvalidateStateEndpoint, (p,ie) => ({}))
     }
 
     // -------------------------------------------------------------------
@@ -196,12 +196,12 @@ export class TestatoPresenterModel extends ClusterfunPresenterModel<TestatoPlaye
 
         if(this.currentRound > this.totalRounds) {
             this.gameState = GeneralGameState.GameOver;
-            this.requestEveryone(GameOverEndpoint, (p,ie) => ({}), true)
+            this.requestEveryone(GameOverEndpoint, (p,ie) => ({}))
             this.saveCheckpoint();
         }    
         else {
             this.gameState = TestatoGameState.Playing;
-            this.requestEveryone(InvalidateStateEndpoint, (p,ie) => ({}), true)
+            this.requestEveryoneAndForget(InvalidateStateEndpoint, (p,ie) => ({}))
             this.saveCheckpoint();
         }
 

--- a/src/games/stressgame/models/ClientModel.ts
+++ b/src/games/stressgame/models/ClientModel.ts
@@ -117,7 +117,7 @@ export class StressatoClientModel extends ClusterfunClientModel  {
     // sendAction 
     // -------------------------------------------------------------------
     protected async sendAction(actionData: any = null) {
-        await this.session.request(StressatoPresenterRelayEndpoint, this.session.presenterId, {
+        await this.session.requestPresenter(StressatoPresenterRelayEndpoint, {
             returnSize: this.returnMessageSize,
             actionData
         });

--- a/src/libs/GameModel/BaseGameModel.ts
+++ b/src/libs/GameModel/BaseGameModel.ts
@@ -443,6 +443,18 @@ export abstract class BaseGameModel  {
     }
 
     // -------------------------------------------------------------------
+    // Create a request listener specifically for a presenter - a request
+    // from any other caller has an error thrown back at it
+    // ------------------------------------------------------------------- 
+    protected listenToEndpointFromPresenter<REQUEST, RESPONSE>(
+        endpoint: MessageEndpoint<REQUEST, RESPONSE>,
+        apiCallback: (request: REQUEST) => RESPONSE | PromiseLike<RESPONSE>) {
+        const listener = this.session.listenPresenter(endpoint, apiCallback);
+        this._messageListeners.push(listener as ClusterfunListener<unknown, unknown>);
+        return listener;
+    }
+
+    // -------------------------------------------------------------------
     // scheduleEvent
     // -------------------------------------------------------------------
     protected scheduleEvent(time: number, event: () => void) {

--- a/src/libs/GameModel/ClusterfunClientModel.ts
+++ b/src/libs/GameModel/ClusterfunClientModel.ts
@@ -140,6 +140,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
     handleGameOverMessage = (message: unknown) => {
         this.gameState = GeneralGameState.GameOver;
         this.saveCheckpoint();
+        return {};
     }
 
     // -------------------------------------------------------------------
@@ -149,6 +150,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
         Logger.info("Presenter has terminated the game")
         this.gameTerminated = true;
         this.quitApp();
+        return {};
     }
 
     prepauseState: string = GeneralGameState.Unknown

--- a/src/libs/GameModel/ClusterfunClientModel.ts
+++ b/src/libs/GameModel/ClusterfunClientModel.ts
@@ -55,11 +55,11 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
 
     reconstitute():void {
         super.reconstitute();
-        this.listenToEndpoint(InvalidateStateEndpoint, this.handleInvalidateStateMessage);
-        this.listenToEndpoint(GameOverEndpoint, this.handleGameOverMessage);
-        this.listenToEndpoint(TerminateGameEndpoint, this.handleTerminateGameMessage);
-        this.listenToEndpoint(PauseGameEndpoint, this.handlePauseMessage);
-        this.listenToEndpoint(ResumeGameEndpoint, this.handleResumeMessage);
+        this.listenToEndpointFromPresenter(InvalidateStateEndpoint, this.handleInvalidateStateMessage);
+        this.listenToEndpointFromPresenter(GameOverEndpoint, this.handleGameOverMessage);
+        this.listenToEndpointFromPresenter(TerminateGameEndpoint, this.handleTerminateGameMessage);
+        this.listenToEndpointFromPresenter(PauseGameEndpoint, this.handlePauseMessage);
+        this.listenToEndpointFromPresenter(ResumeGameEndpoint, this.handleResumeMessage);
 
         // this.session.onError((err) => {
         //     Logger.error(`Session error: ${err}`)
@@ -129,7 +129,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
     // -------------------------------------------------------------------
     //  handleInvalidateStateMessage
     // -------------------------------------------------------------------
-    handleInvalidateStateMessage = (sender: string, message: unknown) => {
+    handleInvalidateStateMessage = (message: unknown) => {
         this._stateIsInvalid = true;
         this.requestGameStateFromPresenter().then(() => this._stateIsInvalid = false);
     }
@@ -137,7 +137,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
     // -------------------------------------------------------------------
     //  
     // -------------------------------------------------------------------
-    handleGameOverMessage = (sender: string, message: unknown) => {
+    handleGameOverMessage = (message: unknown) => {
         this.gameState = GeneralGameState.GameOver;
         this.saveCheckpoint();
     }
@@ -145,7 +145,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
     // -------------------------------------------------------------------
     //  
     // -------------------------------------------------------------------
-    handleTerminateGameMessage = (sender: string, message: unknown) => {
+    handleTerminateGameMessage = (message: unknown) => {
         Logger.info("Presenter has terminated the game")
         this.gameTerminated = true;
         this.quitApp();
@@ -155,7 +155,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
     // -------------------------------------------------------------------
     // 
     // -------------------------------------------------------------------
-    protected handlePauseMessage = (sender: string, message: unknown): any => {
+    protected handlePauseMessage = (message: unknown): any => {
         this.prepauseState = this.gameState;
         this.gameState = GeneralClientGameState.Paused
         this.saveCheckpoint();
@@ -165,7 +165,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
     // -------------------------------------------------------------------
     // 
     // -------------------------------------------------------------------
-    protected handleResumeMessage = (sender: string, message: unknown): any => {
+    protected handleResumeMessage = (message: unknown): any => {
         if(this.prepauseState !== GeneralGameState.Unknown) {
             this.gameState = this.prepauseState;
             this.saveCheckpoint();

--- a/src/libs/GameModel/ClusterfunClientModel.ts
+++ b/src/libs/GameModel/ClusterfunClientModel.ts
@@ -68,12 +68,12 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
         this.subscribe(GeneralGameState.Destroyed, "GameDestroyed", () =>
         {
             if(!this.gameTerminated) {
-                this.session.request(QuitEndpoint, this.session.presenterId, {}).forget();
+                this.session.requestPresenter(QuitEndpoint, {}).forget();
             }
         })
 
         this.gameState = GeneralClientGameState.WaitingToStart;
-        this.session.request(JoinEndpoint, this.session.presenterId, { playerName: this._playerName }).then(ack => {
+        this.session.requestPresenter(JoinEndpoint, { playerName: this._playerName }).then(ack => {
             this.handleJoinAck(ack);
             this._stateIsInvalid = true;
             this.requestGameStateFromPresenter().then(() => this._stateIsInvalid = false);
@@ -94,7 +94,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
         }
         
         if(this.gameState !== GeneralGameState.Destroyed) {
-            this.session.request(PingEndpoint, this.session.presenterId, { pingTime: Date.now() }).then(undefined, (err) => {
+            this.session.requestPresenter(PingEndpoint, { pingTime: Date.now() }).then(undefined, (err) => {
                 Logger.warn("Ping message was not received:", err);
             })
             setTimeout(this.keepAlive, this.KEEPALIVE_INTERVAL_MS)

--- a/src/libs/messaging/SessionHelper.ts
+++ b/src/libs/messaging/SessionHelper.ts
@@ -12,7 +12,6 @@ export interface ISessionHelper {
     readonly roomId: string;
     readonly personalId: string;
     readonly personalSecret: string;
-    readonly presenterId: string;
     listen<REQUEST, RESPONSE>(
         endpoint: MessageEndpoint<REQUEST, RESPONSE>, 
         apiCallback: (sender: string, value: REQUEST) => RESPONSE | PromiseLike<RESPONSE>
@@ -20,6 +19,10 @@ export interface ISessionHelper {
     request<REQUEST, RESPONSE>(
         endpoint: MessageEndpoint<REQUEST, RESPONSE>, 
         receiverId: string, 
+        request: REQUEST
+        ): ClusterfunRequest<REQUEST, RESPONSE>;
+    requestPresenter<REQUEST, RESPONSE>(
+        endpoint: MessageEndpoint<REQUEST, RESPONSE>,
         request: REQUEST
         ): ClusterfunRequest<REQUEST, RESPONSE>;
     addClosedListener(owner: object, listener: (code: number) => void): void;
@@ -42,7 +45,6 @@ export class SessionHelper implements ISessionHelper {
     public get personalId() { return this._messageThing.personalId }
     public get personalSecret() { return this._messageThing.personalSecret }
     private readonly _presenterId: string;
-    public get presenterId() { return this._presenterId }
     private _messageThing: IMessageThing;
     private _closedListeners = new Map<object, (code: number) => void>();
     private _errorSubs: ((err:string)=>void)[] = []
@@ -111,6 +113,13 @@ export class SessionHelper implements ISessionHelper {
             receiverId,
             (this._currentRequestId++).toString(), 
             this._messageThing);
+    }
+
+    //--------------------------------------------------------------------------------------
+    // 
+    //--------------------------------------------------------------------------------------
+    requestPresenter<REQUEST, RESPONSE>(endpoint: MessageEndpoint<REQUEST, RESPONSE>, request: REQUEST) {
+        return this.request(endpoint, this._presenterId, request);
     }
 
     //--------------------------------------------------------------------------------------

--- a/src/libs/messaging/basicEndpoints.ts
+++ b/src/libs/messaging/basicEndpoints.ts
@@ -51,7 +51,7 @@ export const InvalidateStateEndpoint: MessageEndpoint<unknown, unknown> = {
  */
 export const GameOverEndpoint: MessageEndpoint<unknown, unknown> = {
     route: "/basic/lifecycle/gameover",
-    responseRequired: false
+    responseRequired: true
 }
 
 /**
@@ -59,7 +59,7 @@ export const GameOverEndpoint: MessageEndpoint<unknown, unknown> = {
  */
 export const TerminateGameEndpoint: MessageEndpoint<unknown, unknown> = {
     route: "/basic/lifecycle/terminate",
-    responseRequired: false
+    responseRequired: true
 }
 
 /**
@@ -67,7 +67,7 @@ export const TerminateGameEndpoint: MessageEndpoint<unknown, unknown> = {
  */
 export const PauseGameEndpoint: MessageEndpoint<unknown, unknown> = {
     route: "/basic/lifecycle/pause",
-    responseRequired: false
+    responseRequired: true
 }
 
 /**
@@ -75,5 +75,5 @@ export const PauseGameEndpoint: MessageEndpoint<unknown, unknown> = {
  */
  export const ResumeGameEndpoint: MessageEndpoint<unknown, unknown> = {
     route: "/basic/lifecycle/resume",
-    responseRequired: false
+    responseRequired: true
 }


### PR DESCRIPTION
This addresses feedback from #51:

- Hide presenter ID from client, adding these APIs instead:
  - requestPresenter, which sends a message specifically to the presenter
  - listenPresenter, which listens for messages specifically from the presenter and throws if the sender is another client instead
- Add requestEveryoneAndForget, to make sending messages to all clients a bit more ergonomic than just tacking a boolean at the end
- In Lexible, only ask for hints on the first letter. (This was a regression in the other PR)