### PR TITLE
Forget the stress action if needed

### DIFF
--- a/src/games/stressgame/models/ClientModel.ts
+++ b/src/games/stressgame/models/ClientModel.ts
@@ -117,9 +117,14 @@ export class StressatoClientModel extends ClusterfunClientModel  {
     // sendAction 
     // -------------------------------------------------------------------
     protected async sendAction(actionData: any = null) {
-        await this.session.request(StressatoPresenterRelayEndpoint, this.session.presenterId, {
+        const request = this.session.request(StressatoPresenterRelayEndpoint, this.session.presenterId, {
             returnSize: this.returnMessageSize,
             actionData
         });
+        if (!this.returnMessageSize) {
+            request.forget();
+        } else {
+            await request;
+        }
     }
 }


### PR DESCRIPTION
- A return message for sendAction in Stressato is not expected if the "returnSize" value is zero, so forget() the listener in that case.
- This prevents "Could not receive a response" errors from flooding the console during stress tests.