### PR TITLE
Improve Slider performance

### DIFF
--- a/src/libs/components/Slider.tsx
+++ b/src/libs/components/Slider.tsx
@@ -149,8 +149,7 @@ export class Slider extends React.Component<SliderProps>
         }
 
         const childStyle = {
-            left: `${this.st.offsetX}px`,
-            top: `${this.st.offsetY}px`,
+            transform: `translate(${this.st.offsetX}px, ${this.st.offsetY}px)`
         }
 
         return (


### PR DESCRIPTION
- Use `transform()` to position the slider content. This causes the browser to use the compositor instead of the layout engine to position it, which puts it on a separate layer and makes transforms way faster (https://web.dev/stick-to-compositor-only-properties-and-manage-layer-count/)
- Use `requestAnimationFrame()` to manage slider drift. This causes drift to match the device's frame rate and also causes calculations to happen immediately after vsync, reducing the risk of dropped frames.

The result of these changes is that the Lexible client grid is far more performant as it scrolls, eliminating most dropped frames.