### PR TITLE
Replace .forget() with a fire-and-forget endpoint

### DIFF
--- a/src/games/Lexible/models/ClientModel.ts
+++ b/src/games/Lexible/models/ClientModel.ts
@@ -305,9 +305,9 @@ export class LexibleClientModel extends ClusterfunClientModel  {
                     if(this.letterChain.length === 0) this.wordList = []
                 }
 
-                this.session.requestPresenter(LexibleReportTouchLetterEndpoint, {
+                this.session.sendMessageToPresenter(LexibleReportTouchLetterEndpoint, {
                     touchPoint: block.coordinates
-                }).forget();
+                });
                 if (isFirst) {
                     this.session.requestPresenter(LexibleRequestWordHintsEndpoint, {
                         currentWord: this.letterChain.map(block => ({

--- a/src/games/Lexible/models/PresenterModel.ts
+++ b/src/games/Lexible/models/PresenterModel.ts
@@ -431,7 +431,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
                 const letterCoordinates = Array.from(this.recentlyTouchedLetters.values());
                 this.recentlyTouchedLetters.clear();
                 const message: LexibleRecentlyTouchedLettersMessage = { letterCoordinates }
-                this.requestEveryoneAndForget(LexibleServerRecentlyTouchedLettersEndpoint, () => message);
+                this.sendToEveryone(LexibleServerRecentlyTouchedLettersEndpoint, () => message);
             }
         }
     }
@@ -485,7 +485,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
             this.requestEveryone(GameOverEndpoint, (p,ie) => ({}))
         }    
         else {
-            this.requestEveryoneAndForget(InvalidateStateEndpoint, (p, ie) => ({}));
+            this.sendToEveryone(InvalidateStateEndpoint, (p, ie) => ({}));
         }
         this.saveCheckpoint();
     }
@@ -591,7 +591,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
         }
         this.gameState = LexibleGameState.EndOfRound
         this.invokeEvent(LexibleGameEvent.TeamWon, team)
-        this.requestEveryoneAndForget(LexibleEndRoundEndpoint, (p, ie) => {
+        this.sendToEveryone(LexibleEndRoundEndpoint, (p, ie) => {
             return { roundNumber: this.currentRound, winningTeam: team }
         })
     }
@@ -623,7 +623,7 @@ export class LexiblePresenterModel extends ClusterfunPresenterModel<LexiblePlaye
 
         if(word.length > player.longestWord.length) player.longestWord = word;
 
-        this.requestEveryoneAndForget(LexibleBoardUpdateEndpoint, (p, isExited) => {
+        this.sendToEveryone(LexibleBoardUpdateEndpoint, (p, isExited) => {
             return {
                 letters: placedLetters,
                 score: word.length,

--- a/src/games/Lexible/models/lexibleEndpoints.ts
+++ b/src/games/Lexible/models/lexibleEndpoints.ts
@@ -25,7 +25,6 @@ export interface LexibleOnboardClientMessage {
 
 export const LexibleOnboardClientEndpoint: MessageEndpoint<unknown, LexibleOnboardClientMessage> = {
     route: "/games/lexible/lifecycle/onboard-client",
-    responseRequired: true,
     suggestedRetryIntervalMs: 10000,
     suggestedTotalLifetimeMs: 60000
 }
@@ -48,7 +47,6 @@ export const LexibleSwitchTeamEndpoint: MessageEndpoint<
     LexibleSwitchTeamRequest,
     LexibleSwitchTeamResponse> = {
         route: "/games/lexible/lifecycle/switch-team",
-        responseRequired: true,
         suggestedRetryIntervalMs: 2000,
         suggestedTotalLifetimeMs: 10000
     }
@@ -63,9 +61,8 @@ export interface LexibleRecentlyTouchedLettersMessage
     letterCoordinates: Vector2[];
 }
 
-export const LexibleServerRecentlyTouchedLettersEndpoint: MessageEndpoint<LexibleRecentlyTouchedLettersMessage, unknown> = {
-    route: "/games/lexible/juice/recently-touched-letters",
-    responseRequired: false
+export const LexibleServerRecentlyTouchedLettersEndpoint: MessageEndpoint<LexibleRecentlyTouchedLettersMessage, void> = {
+    route: "/games/lexible/juice/recently-touched-letters"
 }
 
 //--------------------------------------------------------------------------------------
@@ -76,9 +73,8 @@ export interface LexibleTouchLetterRequest
     touchPoint: Vector2
 }
 
-export const LexibleReportTouchLetterEndpoint: MessageEndpoint<LexibleTouchLetterRequest, unknown> = {
-    route: "/games/lexible/juice/touch-letter",
-    responseRequired: false
+export const LexibleReportTouchLetterEndpoint: MessageEndpoint<LexibleTouchLetterRequest, void> = {
+    route: "/games/lexible/juice/touch-letter"
 }
 
 //--------------------------------------------------------------------------------------
@@ -96,7 +92,6 @@ export interface LexibleWordHintResponse
 
 export const LexibleRequestWordHintsEndpoint: MessageEndpoint<LexibleWordHintRequest, LexibleWordHintResponse> = {
     route: "/games/lexible/gameplay/get-word-hints",
-    responseRequired: true,
     suggestedRetryIntervalMs: 1000,
     suggestedTotalLifetimeMs: 10000
 }
@@ -114,7 +109,6 @@ export interface LexibleBoardUpdateNotification
 
 export const LexibleBoardUpdateEndpoint: MessageEndpoint<LexibleBoardUpdateNotification, unknown> = {
     route: "/games/lexible/gameplay/update-board",
-    responseRequired: false,
     suggestedRetryIntervalMs: Number.POSITIVE_INFINITY,
     suggestedTotalLifetimeMs: 30000
 }
@@ -138,7 +132,6 @@ export const LexibleSubmitWordEndpoint: MessageEndpoint<
     LexibleWordSubmissionRequest,
     LexibleWordSubmissionResponse> = {
         route: "/games/lexible/gameplay/submit-word",
-        responseRequired: true,
         suggestedRetryIntervalMs: 2000,
         suggestedTotalLifetimeMs: 10000
     }
@@ -154,7 +147,6 @@ export interface LexibleEndOfRoundMessage
 
 export const LexibleEndRoundEndpoint: MessageEndpoint<LexibleEndOfRoundMessage, unknown> = {
     route: "/games/lexible/lifecycle/end-round",
-    responseRequired: true,
     suggestedRetryIntervalMs: 2000,
     suggestedTotalLifetimeMs: 30000
 }

--- a/src/games/TestGame/models/ClientModel.ts
+++ b/src/games/TestGame/models/ClientModel.ts
@@ -136,7 +136,7 @@ export class TestatoClientModel extends ClusterfunClientModel  {
         const hex = Array.from("0123456789ABCDEF");
         let colorStyle = "#";
         for(let i = 0; i < 6; i++) colorStyle += this.randomItem(hex);
-        this.session.requestPresenter(TestatoColorChangeActionEndpoint, { colorStyle }).forget();
+        this.session.sendMessageToPresenter(TestatoColorChangeActionEndpoint, { colorStyle });
     }
    
     // -------------------------------------------------------------------
@@ -144,7 +144,7 @@ export class TestatoClientModel extends ClusterfunClientModel  {
     // -------------------------------------------------------------------
     doMessage(){
         const messages = ["Hi!", "Bye?", "What's up?", "Oh No!", "Hoooooweeee!!", "More gum."]
-        this.session.requestPresenter(TestatoMessageActionEndpoint, { message: this.randomItem(messages)}).forget();
+        this.session.sendMessageToPresenter(TestatoMessageActionEndpoint, { message: this.randomItem(messages)});
     }
    
     // -------------------------------------------------------------------
@@ -154,6 +154,6 @@ export class TestatoClientModel extends ClusterfunClientModel  {
         x = Math.floor(x * 1000)/1000;
         y = Math.floor(y * 1000)/1000;
         
-        this.session.requestPresenter(TestatoTapActionEndpoint, { point: new Vector2(x, y) }).forget();
+        this.session.sendMessageToPresenter(TestatoTapActionEndpoint, { point: new Vector2(x, y) });
     }
 }

--- a/src/games/TestGame/models/PresenterModel.ts
+++ b/src/games/TestGame/models/PresenterModel.ts
@@ -173,7 +173,7 @@ export class TestatoPresenterModel extends ClusterfunPresenterModel<TestatoPlaye
     // -------------------------------------------------------------------
     finishPlayingRound() {
         this.gameState = TestatoGameState.EndOfRound;
-        this.requestEveryoneAndForget(InvalidateStateEndpoint, (p,ie) => ({}))
+        this.sendToEveryone(InvalidateStateEndpoint, (p,ie) => ({}))
     }
 
     // -------------------------------------------------------------------
@@ -200,7 +200,7 @@ export class TestatoPresenterModel extends ClusterfunPresenterModel<TestatoPlaye
         }    
         else {
             this.gameState = TestatoGameState.Playing;
-            this.requestEveryoneAndForget(InvalidateStateEndpoint, (p,ie) => ({}))
+            this.sendToEveryone(InvalidateStateEndpoint, (p,ie) => ({}))
             this.saveCheckpoint();
         }
 

--- a/src/games/TestGame/models/testatoEndpoints.ts
+++ b/src/games/TestGame/models/testatoEndpoints.ts
@@ -3,22 +3,18 @@ import { Vector2 } from "libs/types";
 
 export const TestatoOnboardClientEndpoint: MessageEndpoint<unknown, { roundNumber: number, customText: string, state: string }> = {
     route: "/games/testato/lifecycle/onboard",
-    responseRequired: true,
     suggestedRetryIntervalMs: 5000,
     suggestedTotalLifetimeMs: 30000
 }
 
-export const TestatoColorChangeActionEndpoint: MessageEndpoint<{ colorStyle: string }, unknown> = {
+export const TestatoColorChangeActionEndpoint: MessageEndpoint<{ colorStyle: string }, void> = {
     route: "/games/testato/actions/color-change",
-    responseRequired: false
 }
 
-export const TestatoMessageActionEndpoint: MessageEndpoint<{ message: string }, unknown> = {
+export const TestatoMessageActionEndpoint: MessageEndpoint<{ message: string }, void> = {
     route: "/games/testato/actions/message",
-    responseRequired: false
 }
 
-export const TestatoTapActionEndpoint: MessageEndpoint<{ point: Vector2 }, unknown> = {
+export const TestatoTapActionEndpoint: MessageEndpoint<{ point: Vector2 }, void> = {
     route: "/games/testato/actions/tap",
-    responseRequired: false
 }

--- a/src/games/stressgame/models/ClientModel.ts
+++ b/src/games/stressgame/models/ClientModel.ts
@@ -2,7 +2,7 @@ import { ISessionHelper, ClusterFunGameProps,
     ClusterfunClientModel, ITelemetryLogger, 
     IStorage, ITypeHelper } from "libs";
 import { action, makeObservable, observable } from "mobx";
-import { StressatoPresenterRelayEndpoint } from "./stressatoEndpoints";
+import { StressatoPresenterRelayWithReturnEndpoint, StressatoPresenterRelayWithoutReturnEndpoint } from "./stressatoEndpoints";
 
 
 // -------------------------------------------------------------------
@@ -117,14 +117,14 @@ export class StressatoClientModel extends ClusterfunClientModel  {
     // sendAction 
     // -------------------------------------------------------------------
     protected async sendAction(actionData: any = null) {
-        const request = this.session.requestPresenter(StressatoPresenterRelayEndpoint, {
-            returnSize: this.returnMessageSize,
-            actionData
-        });
-        if (!this.returnMessageSize) {
-            request.forget();
+        if (this.returnMessageSize) {
+            await this.session.requestPresenter(
+                StressatoPresenterRelayWithReturnEndpoint, 
+                { returnSize: this.returnMessageSize, actionData });
         } else {
-            await request;
+            this.session.sendMessageToPresenter(
+                StressatoPresenterRelayWithoutReturnEndpoint, 
+                { actionData });
         }
     }
 }

--- a/src/games/stressgame/models/PresenterModel.ts
+++ b/src/games/stressgame/models/PresenterModel.ts
@@ -3,7 +3,7 @@ import { ClusterFunPlayer, ISessionHelper,
     ClusterFunGameProps, ClusterfunPresenterModel, 
     ITelemetryLogger, IStorage, ITypeHelper, 
     PresenterGameState} from "libs";
-import { StressatoPresenterRelayEndpoint } from "./stressatoEndpoints";
+import { StressatoPresenterRelayWithReturnEndpoint, StressatoPresenterRelayWithoutReturnEndpoint } from "./stressatoEndpoints";
 
 
 export enum StressatoPlayerStatus {
@@ -167,7 +167,8 @@ export class StressatoPresenterModel extends ClusterfunPresenterModel<StressatoP
     // -------------------------------------------------------------------
     reconstitute() {
         super.reconstitute();
-        this.listenToEndpoint(StressatoPresenterRelayEndpoint, this.handlePlayerAction);
+        this.listenToEndpoint(StressatoPresenterRelayWithReturnEndpoint, this.handleRelayWithReturn);
+        this.listenToEndpoint(StressatoPresenterRelayWithoutReturnEndpoint, this.handleRelayWithoutReturn);
     }
 
 
@@ -215,13 +216,15 @@ export class StressatoPresenterModel extends ClusterfunPresenterModel<StressatoP
     // -------------------------------------------------------------------
     //  handlePlayerAction
     // -------------------------------------------------------------------
-    handlePlayerAction = (sender: string, message: { returnSize: number, actionData: string }) => {
-        if(message.returnSize) {
-            return { actionData: seedString.substring(0, message.returnSize)};
-        } else {
-            return undefined;
-        }
+    handleRelayWithReturn = (sender: string, message: { returnSize: number, actionData: string }) => {
+        return { actionData: seedString.substring(0, message.returnSize)};
+    }
 
+    // -------------------------------------------------------------------
+    //  handlePlayerAction
+    // -------------------------------------------------------------------
+    handleRelayWithoutReturn = (sender: string, message: { actionData: string }) => {
+        return undefined; // do nothing
     }
 
 }

--- a/src/games/stressgame/models/stressatoEndpoints.ts
+++ b/src/games/stressgame/models/stressatoEndpoints.ts
@@ -1,8 +1,11 @@
 import MessageEndpoint from "libs/messaging/MessageEndpoint";
 
-export const StressatoPresenterRelayEndpoint: MessageEndpoint<
+export const StressatoPresenterRelayWithReturnEndpoint: MessageEndpoint<
     { returnSize: number, actionData: string }, 
     { actionData: string } | undefined> = {
-    route: "/utils/stressato/relay",
-    responseRequired: false
+    route: "/utils/stressato/relay-with-return"
+}
+
+export const StressatoPresenterRelayWithoutReturnEndpoint: MessageEndpoint<{ actionData: string }, void> = {
+    route: "/utils/stressato/relay-without-return"
 }

--- a/src/libs/GameModel/ClusterfunClientModel.ts
+++ b/src/libs/GameModel/ClusterfunClientModel.ts
@@ -68,7 +68,7 @@ export abstract class ClusterfunClientModel extends BaseGameModel  {
         this.subscribe(GeneralGameState.Destroyed, "GameDestroyed", () =>
         {
             if(!this.gameTerminated) {
-                this.session.requestPresenter(QuitEndpoint, {}).forget();
+                this.session.sendMessageToPresenter(QuitEndpoint, {});
             }
         })
 

--- a/src/libs/GameModel/ClusterfunPresenterModel.ts
+++ b/src/libs/GameModel/ClusterfunPresenterModel.ts
@@ -340,7 +340,7 @@ export abstract class ClusterfunPresenterModel<PlayerType extends ClusterFunPlay
             if(player.playerId !== this.session.personalId) {
                 const request = generateRequest(player, isExited);
                 if(request) {
-                    const promise = this.session.request(endpoint, player.playerId, request);
+                    const promise = this.session.request<REQUEST, RESPONSE>(endpoint, player.playerId, request);
                     return promise;
                 } else {
                     return Promise.resolve(undefined)
@@ -352,20 +352,20 @@ export abstract class ClusterfunPresenterModel<PlayerType extends ClusterFunPlay
     }
 
     // -------------------------------------------------------------------
-    //  requestEveryoneAndForget - make a request to all players that we promptly forget
+    //  sendToEveryone - send a fire-and-forget message to all players
     //  generateMessage should return falsy if a message should not go
     //  to that player
     // -------------------------------------------------------------------
-    async requestEveryoneAndForget<REQUEST, RESPONSE>(
-        endpoint: MessageEndpoint<REQUEST, RESPONSE>, 
-        generateRequest: (player: PlayerType, isExited: boolean) => REQUEST | undefined): Promise<void> {
+    sendToEveryone<MESSAGE>(
+        endpoint: MessageEndpoint<MESSAGE, void>, 
+        generateRequest: (player: PlayerType, isExited: boolean) => MESSAGE | undefined): void {
 
         const sendToPlayer = (isExited: boolean) => async (player:PlayerType): Promise<void> => {
             // Don't send to self
             if(player.playerId !== this.session.personalId) {
                 const request = generateRequest(player, isExited);
                 if(request) {
-                    this.session.request(endpoint, player.playerId, request).forget();
+                    this.session.sendMessage(endpoint, player.playerId, request);
                 }
             }
         }

--- a/src/libs/comms/ClusterFunRoutingHeader.ts
+++ b/src/libs/comms/ClusterFunRoutingHeader.ts
@@ -5,5 +5,5 @@
 export interface ClusterFunRoutingHeader {
     requestId: string;
     route: string;
-    role: "request" | "response" | "error";
+    role: "message" | "request" | "response" | "error";
 }

--- a/src/libs/comms/messageParsing.ts
+++ b/src/libs/comms/messageParsing.ts
@@ -13,7 +13,13 @@ export function parseMessage(data: string): { header: ClusterFunMessageHeader, r
     }
     const header = JSON.parse(regexMatch.groups!["header"]) as ClusterFunMessageHeader;
     const routing = JSON.parse(regexMatch.groups!["routing"]) as ClusterFunRoutingHeader;
-    const payload = JSON.parse(regexMatch.groups!["payload"]);
+    const payloadString = regexMatch.groups!["payload"];
+    let payload: any;
+    if (payloadString === "" || payloadString === "undefined") {
+        payload = undefined;
+    } else {
+        payload = JSON.parse(regexMatch.groups!["payload"]);
+    }
     return { header, routing, payload };
 }
 

--- a/src/libs/messaging/ClusterfunRequest.ts
+++ b/src/libs/messaging/ClusterfunRequest.ts
@@ -102,7 +102,7 @@ export default class ClusterfunRequest<REQUEST, RESPONSE> implements PromiseLike
         delete this._rejectedCallbacks;
         this._response = value;
         this._state = RequestState.Resolved;
-        this.forget();
+        this.cleanup();
         for (const callback of fulfilledCallbacks) {
             callback(this._response);
         }
@@ -117,7 +117,7 @@ export default class ClusterfunRequest<REQUEST, RESPONSE> implements PromiseLike
         delete this._rejectedCallbacks;
         this._error = error;
         this._state = RequestState.Rejected;
-        this.forget();
+        this.cleanup();
         for (const callback of rejectedCallbacks) {
             callback(this._error);
         }
@@ -162,9 +162,9 @@ export default class ClusterfunRequest<REQUEST, RESPONSE> implements PromiseLike
         })
     }
 
-    forget(): void {
-        if (this._state === RequestState.Unsettled && this.endpoint.responseRequired) {
-            Logger.warn(`Called forget() on a request that requires a response (route ${this.endpoint.route})`)
+    private cleanup(): void {
+        if (this._state === RequestState.Unsettled) {
+            Logger.warn(`Attempted cleanup on a request that has not been resolved`)
         }
         if (this._timeout) {
             clearTimeout(this._timeout);

--- a/src/libs/messaging/MessageEndpoint.ts
+++ b/src/libs/messaging/MessageEndpoint.ts
@@ -1,5 +1,5 @@
 /**
- * A reference object that assists users in setting up endpoints.
+ * A reference object that assists users in setting up request/response endpoints.
  * Each game should declare a module containing the endpoints
  * they want to support.
  */
@@ -10,20 +10,13 @@ export default interface MessageEndpoint<REQUEST, RESPONSE> {
      */
     route: string;
     /**
-     * Whether or not a response message is expected.
-     * - If a response is expected, a warning will be emitted if a sender
-     *   calls `forget()` on the request, or if a receiver provides
-     *   an undefined response (in which case no return message is sent).
-     */
-    responseRequired: boolean;
-    /**
-     * The suggested total lifetime of the response, after which
+     * The suggested total lifetime of the request, after which
      * the request is automatically rejected with a timeout error.
      * Defaults to 30 seconds.
      */
     suggestedTotalLifetimeMs?: number;
     /**
-     * The suggested retry interval of the response - the message will be
+     * The suggested retry interval of the request - the message will be
      * resent as needed. 
      * - If the number is infinity (the default), no retries will be sent.
      * - If the number is 0 or less, the message will be retried as often

--- a/src/libs/messaging/basicEndpoints.ts
+++ b/src/libs/messaging/basicEndpoints.ts
@@ -8,7 +8,6 @@ export const JoinEndpoint: MessageEndpoint<
     { isRejoin: boolean, didJoin: boolean, joinError?: string }
     > = {
     route: "/basic/handshake/join",
-    responseRequired: true,
     suggestedRetryIntervalMs: 1000,
     suggestedTotalLifetimeMs: 10000
 }
@@ -17,9 +16,8 @@ export const JoinEndpoint: MessageEndpoint<
  * Endpoint for informing the presenter that a client
  * has quit
  */
-export const QuitEndpoint: MessageEndpoint<unknown, unknown> = {
+export const QuitEndpoint: MessageEndpoint<unknown, void> = {
     route: "/basic/handshake/quit",
-    responseRequired: false
 }
 
 /**
@@ -30,7 +28,6 @@ export const PingEndpoint: MessageEndpoint<
     { pingTime: number, localTime: number }
     > = {
     route: "/basic/ping",
-    responseRequired: true,
     suggestedRetryIntervalMs: Number.POSITIVE_INFINITY,
     suggestedTotalLifetimeMs: 5000
 }
@@ -41,9 +38,8 @@ export const PingEndpoint: MessageEndpoint<
  * message by invoking the game-specific endpoint to fully
  * resync state.
  */
-export const InvalidateStateEndpoint: MessageEndpoint<unknown, unknown> = {
+export const InvalidateStateEndpoint: MessageEndpoint<unknown, void> = {
     route: "/basic/invalidate",
-    responseRequired: false
 }
 
 /**
@@ -51,7 +47,6 @@ export const InvalidateStateEndpoint: MessageEndpoint<unknown, unknown> = {
  */
 export const GameOverEndpoint: MessageEndpoint<unknown, unknown> = {
     route: "/basic/lifecycle/gameover",
-    responseRequired: true
 }
 
 /**
@@ -59,7 +54,6 @@ export const GameOverEndpoint: MessageEndpoint<unknown, unknown> = {
  */
 export const TerminateGameEndpoint: MessageEndpoint<unknown, unknown> = {
     route: "/basic/lifecycle/terminate",
-    responseRequired: true
 }
 
 /**
@@ -67,7 +61,6 @@ export const TerminateGameEndpoint: MessageEndpoint<unknown, unknown> = {
  */
 export const PauseGameEndpoint: MessageEndpoint<unknown, unknown> = {
     route: "/basic/lifecycle/pause",
-    responseRequired: true
 }
 
 /**
@@ -75,5 +68,4 @@ export const PauseGameEndpoint: MessageEndpoint<unknown, unknown> = {
  */
  export const ResumeGameEndpoint: MessageEndpoint<unknown, unknown> = {
     route: "/basic/lifecycle/resume",
-    responseRequired: true
 }


### PR DESCRIPTION
- Add sendMessage and sendMessageToPresenter to SessionHelper - these send messages without providing callbacks
- Fire-and-forget messages never provide responses, request messages always do, even if either message is falsy.
- Fire-and-forget messages must use endpoints with a `void` response type.
- Remove the "responseRequired" property